### PR TITLE
Re-apply original copyright years

### DIFF
--- a/lib_trycatch/api/trycatch.h
+++ b/lib_trycatch/api/trycatch.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2013-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef _trycatch_h_

--- a/lib_trycatch/src/trycatch.c
+++ b/lib_trycatch/src/trycatch.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2013-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <setjmp.h>

--- a/lib_trycatch/src/trycatch_asm.S
+++ b/lib_trycatch/src/trycatch_asm.S
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2013-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>

--- a/lib_trycatch/src/trycatch_impl.h
+++ b/lib_trycatch/src/trycatch_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2013-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef _trycatch_impl_h_


### PR DESCRIPTION
Now that the source checker script in infr_apps has been fixed, the original copyright start dates can be re-applied.